### PR TITLE
increase maxRequestsPerCrawl

### DIFF
--- a/main.js
+++ b/main.js
@@ -219,7 +219,7 @@ Apify.main(async () => {
 
     handlePageTimeoutSecs: 120,
 
-    maxRequestsPerCrawl: 750,
+    maxRequestsPerCrawl: 75000,
 
     launchContext: {
       useChrome: true,


### PR DESCRIPTION
I haven't used a mac, but when applying this to CA I encountered issues with the size of maxRequestsPerCrawl. I increased this dramatically and it worked fine.